### PR TITLE
Updated webpack-hot-middleware to version 2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "url-loader": "0.5.6",
     "webpack": "1.12.2",
     "webpack-dev-middleware": "1.2.0",
-    "webpack-hot-middleware": "2.3.0"
+    "webpack-hot-middleware": "2.4.1"
   }
 }


### PR DESCRIPTION
:rocket:

webpack-hot-middleware just published version 2.4.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 6 commits (ahead by 6, behind by 0).
- [5a841b4](https://github.com/glenjamin/webpack-hot-middleware/commit/5a841b430743a7e3c58ef132a93dcfbd46483d3e): 2.4.1
- [dbf6f63](https://github.com/glenjamin/webpack-hot-middleware/commit/dbf6f6384bd387923c80f208c92c2442f6df6ab6): Merge pull request #32 from Blitz2145/patch-1
- [52926a3](https://github.com/glenjamin/webpack-hot-middleware/commit/52926a3c09e6dc58bf248e3bfe27a4a04e851bdc): Path Option was broken
- [be089c8](https://github.com/glenjamin/webpack-hot-middleware/commit/be089c83b2a97d868d21064db49f75f197d18d3d): 2.4.0
- [5295be0](https://github.com/glenjamin/webpack-hot-middleware/commit/5295be0cf56620f51766b72516326672cba47941): Make EventSource detection more naive (fixes #31)
- [83b5dcc](https://github.com/glenjamin/webpack-hot-middleware/commit/83b5dcc8a9607fa01e5dc1f2bdc7f31cb3dd0890): Provide client options to disable logging

See the [full diff](https://github.com/glenjamin/webpack-hot-middleware/compare/ad98aeb98e335f09aad2c175b70db56c22012c73...5a841b430743a7e3c58ef132a93dcfbd46483d3e).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
